### PR TITLE
Handle rate limit

### DIFF
--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -175,7 +175,7 @@ class Commands(commands.Cog):
                 line_read = await process.stdout.readline()
                 line = line_read.decode('utf-8').rstrip()
                 if line:
-                    await asyncio.sleep(random.random() * 5+1)  # handles rate limit when using multiple servers
+                    await asyncio.sleep(random.random() * 6+2)  # handles rate limit when using multiple servers
                     await handle_output_line(ctx, line)
 
             # no error while running the command

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -175,7 +175,7 @@ class Commands(commands.Cog):
                 line_read = await process.stdout.readline()
                 line = line_read.decode('utf-8').rstrip()
                 if line:
-                    await asyncio.sleep(random.random())  # handles rate limit when using multiple servers
+                    await asyncio.sleep(random.random() + 1)  # handles rate limit when using multiple servers
                     await handle_output_line(ctx, line)
 
             # no error while running the command

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -138,6 +138,7 @@ class Commands(commands.Cog):
         usage = line_contents[0].rstrip()
         user = line_contents[-1]
 
+        await asyncio.sleep(random.random() + 4)  # handles rate limit when using multiple servers
         await self.home_message_sent.edit(embed=self.home_embed.add_field(
             name=user, value=usage, inline=True))
 
@@ -175,7 +176,6 @@ class Commands(commands.Cog):
                 line_read = await process.stdout.readline()
                 line = line_read.decode('utf-8').rstrip()
                 if line:
-                    await asyncio.sleep(random.random() + 3)  # handles rate limit when using multiple servers
                     await handle_output_line(ctx, line)
 
             # no error while running the command

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -175,7 +175,7 @@ class Commands(commands.Cog):
                 line_read = await process.stdout.readline()
                 line = line_read.decode('utf-8').rstrip()
                 if line:
-                    await asyncio.sleep(random.random() * 2)  # handles rate limit when using multiple servers
+                    await asyncio.sleep(random.random() + 3)  # handles rate limit when using multiple servers
                     await handle_output_line(ctx, line)
 
             # no error while running the command

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -167,7 +167,7 @@ class Commands(commands.Cog):
         handle_output_line: function
             function to handle each line of output produced by the command
         """
-        async with ctx.channel.typing(), self.bot.bot_text_channel.typing():
+        async with self.bot.bot_text_channel.typing():
             process = await asyncio.create_subprocess_shell(
                 cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
 

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -7,6 +7,7 @@ Commands Cog - bot commands
 
 import asyncio
 import logging
+import random
 import signal
 import discord
 from functools import partial
@@ -26,6 +27,7 @@ class Commands(commands.Cog):
         self.logger = logging.getLogger(__name__)
         self.home_embed = None
         self.home_message_sent = None
+        random.seed(self.bot.server_name)
 
     async def cog_before_invoke(self, ctx):
         """Called before each command invocation"""
@@ -165,7 +167,7 @@ class Commands(commands.Cog):
         handle_output_line: function
             function to handle each line of output produced by the command
         """
-        async with ctx.channel.typing():
+        async with ctx.channel.typing(), self.bot.bot_text_channel.typing():
             process = await asyncio.create_subprocess_shell(
                 cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
 
@@ -174,6 +176,7 @@ class Commands(commands.Cog):
                 line_read = await process.stdout.readline()
                 line = line_read.decode('utf-8').rstrip()
                 if line:
+                    await asyncio.sleep(random.random())  # handles rate limit when using multiple servers
                     await handle_output_line(ctx, line)
 
             # no error while running the command

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -7,6 +7,7 @@ Commands Cog - bot commands
 
 import asyncio
 import logging
+import random
 import signal
 import discord
 from functools import partial

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -175,7 +175,7 @@ class Commands(commands.Cog):
                 line_read = await process.stdout.readline()
                 line = line_read.decode('utf-8').rstrip()
                 if line:
-                    await asyncio.sleep(random.random() * 5)  # handles rate limit when using multiple servers
+                    await asyncio.sleep(random.random() * 5+1)  # handles rate limit when using multiple servers
                     await handle_output_line(ctx, line)
 
             # no error while running the command

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -175,7 +175,8 @@ class Commands(commands.Cog):
                 line_read = await process.stdout.readline()
                 line = line_read.decode('utf-8').rstrip()
                 if line:
-                    await asyncio.sleep(random.random() * 6+2)  # handles rate limit when using multiple servers
+                    if self.bot.servers > 1:  # handles rate limit when using multiple servers
+                        await asyncio.sleep(random.random() * (self.bot.servers*2) + (self.bot.servers*0.6))
                     await handle_output_line(ctx, line)
 
             # no error while running the command

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -7,7 +7,6 @@ Commands Cog - bot commands
 
 import asyncio
 import logging
-import random
 import signal
 import discord
 from functools import partial
@@ -27,7 +26,6 @@ class Commands(commands.Cog):
         self.logger = logging.getLogger(__name__)
         self.home_embed = None
         self.home_message_sent = None
-        random.seed(self.bot.server_name)
 
     async def cog_before_invoke(self, ctx):
         """Called before each command invocation"""

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -138,7 +138,6 @@ class Commands(commands.Cog):
         usage = line_contents[0].rstrip()
         user = line_contents[-1]
 
-        await asyncio.sleep(random.random() + 4)  # handles rate limit when using multiple servers
         await self.home_message_sent.edit(embed=self.home_embed.add_field(
             name=user, value=usage, inline=True))
 
@@ -176,6 +175,7 @@ class Commands(commands.Cog):
                 line_read = await process.stdout.readline()
                 line = line_read.decode('utf-8').rstrip()
                 if line:
+                    await asyncio.sleep(random.random() * 5)  # handles rate limit when using multiple servers
                     await handle_output_line(ctx, line)
 
             # no error while running the command

--- a/hpc_bot/cogs/commands.py
+++ b/hpc_bot/cogs/commands.py
@@ -175,7 +175,7 @@ class Commands(commands.Cog):
                 line_read = await process.stdout.readline()
                 line = line_read.decode('utf-8').rstrip()
                 if line:
-                    await asyncio.sleep(random.random() + 1)  # handles rate limit when using multiple servers
+                    await asyncio.sleep(random.random() * 2)  # handles rate limit when using multiple servers
                     await handle_output_line(ctx, line)
 
             # no error while running the command

--- a/hpc_bot/config/hpc_botrc.json
+++ b/hpc_bot/config/hpc_botrc.json
@@ -1,5 +1,6 @@
 {
   "log": "~/.local/var/hpc_bot/hpc-bot.log",
   "token": "ADD TOKEN (see https://discordapp.com/developers/applications/me')",
-  "bot_text_channel": "ADD CHANNEL HERE"
+  "bot_text_channel": "ADD CHANNEL HERE",
+  "servers": 1
 }

--- a/hpc_bot/hpc_bot.py
+++ b/hpc_bot/hpc_bot.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import logging
 import os
+import random
 import socket
 import discord
 import requests
@@ -92,6 +93,7 @@ def main():
     bot.add_cog(cogs.Commands(bot))
     bot.help_command = commands.MinimalHelpCommand()
     bot.server_name = socket.gethostname()
+    random.seed(bot.server_name)
 
     # bot server color
     image_request = requests.get(f'https://raw.githubusercontent.com/CoBiG2/hpc-bot/{bot.server_name}/img.png')

--- a/hpc_bot/hpc_bot.py
+++ b/hpc_bot/hpc_bot.py
@@ -41,6 +41,8 @@ def config_parser(cli):
         os.makedirs(os.path.dirname(cli.log_file))
     if cli.bot_text_channel is None:
         cli.bot_text_channel = configs['bot_text_channel']
+    if cli.servers is None:
+        cli.servers = configs['servers']
 
     return cli
 
@@ -66,6 +68,10 @@ def arguments_handler():
                      dest='bot_text_channel',
                      help='Text channel to join in discord',
                      default='hpc-bots')
+    cli.add_argument('-s',
+                     dest='servers',
+                     help='How many servers are using this token (handling rate-limits)',
+                     default=1)
     cli = cli.parse_args()
 
     if cli.config is not None:
@@ -93,6 +99,7 @@ def main():
     bot.add_cog(cogs.Commands(bot))
     bot.help_command = commands.MinimalHelpCommand()
     bot.server_name = socket.gethostname()
+    bot.servers = cli.servers
     random.seed(bot.server_name)
 
     # bot server color


### PR DESCRIPTION
Because multiple servers can use the same bot token (and in our case, they do) discord.py rate limit handling capabilities is basically bypassed.
By adding some random delay to the message sending, this can be solved, somewhat.